### PR TITLE
Nodeランタイムで関数を実行するにあたり、より良い構成に修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "author": "",
   "license": "ISC",
-  "type": "module",
   "dependencies": {
     "axios": "^1.3.4"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,11 @@ provider:
         - "lightsail:StopInstance"
       Resource: "*"
 
+package:
+  patterns:
+    - "!**"
+    - "index.js"
+
 functions:
   RunSchedules:
     handler: index.handler

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "ESNext",
+    // Nodeで実行するのでCommonJS(package.jsonでtype: "module"の記述を行い、Lambda関数にアップすることでESM形式での動作も可能と言えば可能。する意味ない気がするのでNodeで実行する以上はCommonJSで良さそう)
+    "module": "CommonJS",
     "preserveConstEnums": true,
     "strictNullChecks": true,
     // ソースマップのjsを出力しない
@@ -7,10 +10,8 @@
     // 自分用のコメントをLambda関数にデプロイされるindex.jsに含めない
     "removeComments": true,
     "allowJs": true,
-    "target": "ES6",
     "outDir": ".build",
     "moduleResolution": "node",
-    "lib": ["es2015"],
     "rootDir": "./"
   }
 }


### PR DESCRIPTION
- tsconfig.jsonでコンパイルによって生成されるindex.jsのコードの形式がCommonJSとなるようmodule設定を追加
  - これによってpackage.jsonのtype: "module"の設定を行わずにNode.jsで実行可能となった
  - package.jsonが不要となったのでserverless.ymlのpackage設定でLambda関数に含めないようにするルールを復活
  - package.jsonからtype: "module"のルール自体を削除